### PR TITLE
Harden telseq against integer overflows

### DIFF
--- a/src/Telseq/telseq.h
+++ b/src/Telseq/telseq.h
@@ -13,6 +13,7 @@
 #include <vector>
 #include <map>
 #include <sstream>
+#include <cstdint>
 #include "config.h"
 #include "Util.h"
 
@@ -32,7 +33,7 @@ namespace ScanParameters{
 	static unsigned int READ_LENGTH = 100;
 	static std::string PATTERN="TTAGGG";
 	static std::string PATTERN_REVCOMP="CCCTAA";
-	const unsigned int TELOMERE_ENDS = 46;
+	const uint64_t TELOMERE_ENDS = 46;
 	const float GC_LOWERBOUND = 0.4;
 	const float GC_UPPERBOUND = 0.6;
 	const float GC_BINSIZE = 0.02;
@@ -41,8 +42,8 @@ namespace ScanParameters{
 	const float GC_TELOMERIC_UPPERBOUND = 0.52;
 
 	// maximum motif counts. add 1 to include 0 count.
-	static int TEL_MOTIF_N = READ_LENGTH/PATTERN.size() +1;
-	const int TEL_MOTIF_CUTOFF = 7;
+	static uint64_t TEL_MOTIF_N = READ_LENGTH/PATTERN.size() +1;
+	const uint64_t TEL_MOTIF_CUTOFF = 7;
 	const int GC_BIN_N = (int) ((GC_UPPERBOUND-GC_LOWERBOUND)/GC_BINSIZE+0.5);
 
 	const std::string LABEL_RG="ReadGroup";
@@ -65,25 +66,25 @@ struct ScanResults
 	std::string sample;
 	std::string lib;
 	std::string bam;
-	std::vector<int> telcounts;
-	std::vector<int> gccounts;
-	unsigned int numTotal;
-	unsigned int numMapped;
-	unsigned int numDuplicates;
+	std::vector<uint64_t> telcounts;
+	std::vector<uint64_t> gccounts;
+	uint64_t numTotal;
+	uint64_t numMapped;
+	uint64_t numDuplicates;
 	double telLenEstimate;
 
 	// logging data
-	unsigned int n_totalunfiltered = 0;
-	unsigned int n_exreadsExcluded = 0;
-	unsigned int n_exreadsChrUnmatched=0;
+	uint64_t n_totalunfiltered = 0;
+	uint64_t n_exreadsExcluded = 0;
+	uint64_t n_exreadsChrUnmatched=0;
 
 	ScanResults() { setDefaults(); }
 
     // Set reasonable default values for the qc filters
     void setDefaults()
     {
-		telcounts = std::vector<int>(ScanParameters::TEL_MOTIF_N,0);
-		gccounts = std::vector<int>(ScanParameters::GC_BIN_N,0);
+		telcounts = std::vector<uint64_t>(ScanParameters::TEL_MOTIF_N,0);
+		gccounts = std::vector<uint64_t>(ScanParameters::GC_BIN_N,0);
         numTotal = 0;
         numMapped = 0;
         numDuplicates = 0;


### PR DESCRIPTION
I ran telseq on a number of very deep (~120X) whole genomes, where I wanted to treat everything as one read group.

I found that in almost all of my samples, I got an overflow for the length estimate (which was reported as a large negative number).

This PR replaces all of the `int` and `unsigned int` types with `uint64_t`. This should prevent this from happening, given that it's not wild to hit 2 billion + reads, and assuming the compiler is generous enough to give an int 32 bits in the first place. I don't see any values that could ever be negative, but please replace `uint64_t` with `int64_t` if I've somehow missed one.

It probably doubles the memory usages on most systems, though memory usage of telseq seems to be quite low.